### PR TITLE
Fix omp compilation after recent API changes

### DIFF
--- a/dprt/cuBQL/CuBQLBackend.h
+++ b/dprt/cuBQL/CuBQLBackend.h
@@ -122,7 +122,7 @@ namespace dprt {
       this->count = count;
       this->elements = (T*)omp_target_alloc(count*sizeof(T),
                                             context->gpuID);
-      if (std::is_same<T,INPUT_T>) {
+      if (std::is_same<T,INPUT_T>()) {
         omp_target_memcpy((void*)this->elements,(void*)elements,
                           count*sizeof(T),
                           0,0,

--- a/dprt/cuBQL/InstanceGroup.cu
+++ b/dprt/cuBQL/InstanceGroup.cu
@@ -380,7 +380,7 @@ namespace dprt {
                                  DPRTHit *hits,
                                  int numRays,
                                  uint64_t flags,
-                                 int dbg_rayID)
+                                 int dprt_dbg_rayID)
     {
       int tid = kernel.workIdx();//threadIdx.x+blockIdx.x*blockDim.x;
       if (tid >= numRays) return;
@@ -388,7 +388,7 @@ namespace dprt {
 #ifdef NDEBUG
       const bool dbg = false;
 #else
-      bool dbg = tid == dbg_rayID;
+      bool dbg = tid == dprt_dbg_rayID;
 #endif
 
       DPRTHit hit = hits[tid];
@@ -478,7 +478,7 @@ namespace dprt {
                                getDD(),
                                d_rays,d_hits,numRays,
                                flags,
-                               dbg_rayID);
+                               dprt_dbg_rayID);
 #else
         int bs = 128;
         int nb = divRoundUp(numRays,bs);

--- a/dprt/cuBQL/Triangles.cu
+++ b/dprt/cuBQL/Triangles.cu
@@ -46,7 +46,7 @@ namespace dprt {
                                    const std::vector<dprt::TriangleMesh *> &meshes)
       : dprt::TrianglesGroup(context,meshes)
     {
-#ifndef DP_OMP
+#ifndef DPRT_OMP
       CUBQL_CUDA_SYNC_CHECK();
       SetActiveGPU forDuration(context->gpuID);
 #endif
@@ -58,7 +58,7 @@ namespace dprt {
         numTrisTotal += geom->indices.count;
       }
       impl_box_t   *d_primBounds = nullptr;
-#ifdef DP_OMP
+#ifdef DPRT_OMP
       d_meshDDs
         = (TriangleMesh::DD*)
         omp_target_alloc(devMeshes.size()*sizeof(TriangleMesh::DD),
@@ -89,7 +89,7 @@ namespace dprt {
       for (int meshID=0;meshID<(int)meshes.size();meshID++) {
         TriangleMesh *mesh = (TriangleMesh *)meshes[meshID];
         int count = mesh->indices.count;
-#if DP_OMP
+#if DPRT_OMP
 # pragma omp target device(context->gpuID)
 # pragma omp teams distribute parallel for
         for (int i=0;i<count;i++)
@@ -112,7 +112,7 @@ namespace dprt {
 #endif
         offset += count;
       }
-#if DP_OMP
+#if DPRT_OMP
       // temporarily copy all back to host because we need to use
       // cubql host builder...
       std::vector<PrimRef> h_primRefs(numTrisTotal);
@@ -185,7 +185,7 @@ namespace dprt {
   
     TrianglesGroup::~TrianglesGroup()
     {
-#if DP_OMP
+#if DPRT_OMP
       omp_target_free(bvh.primIDs,context->gpuID);
       omp_target_free(bvh.nodes,context->gpuID);
       omp_target_free(d_meshDDs,context->gpuID);

--- a/dprt/cuBQL/Triangles.cu
+++ b/dprt/cuBQL/Triangles.cu
@@ -90,6 +90,7 @@ namespace dprt {
         TriangleMesh *mesh = (TriangleMesh *)meshes[meshID];
         int count = mesh->indices.count;
 #if DPRT_OMP
+        TriangleMesh::DD meshDD = mesh->getDD();
 # pragma omp target device(context->gpuID)
 # pragma omp teams distribute parallel for
         for (int i=0;i<count;i++)
@@ -98,8 +99,7 @@ namespace dprt {
                                  d_primRefs+offset,
                                  d_primBounds+offset,
                                  count,
-                                 mesh->getDD());
-        PING;
+                                 meshDD);
 #else
         int bs = 128;
         int nb = divRoundUp(count,bs);


### PR DESCRIPTION
This PR fixes some of the stale names in the OpenMP pathway now that deepeeRT's internal naming has been made more consistent with 1.x. I have successfully compiled after the changes with the NVHPC compilers.

Changes 
-
- Fixed the call to `std::is_same<T, INPUT_T>` in the OpenMP path inside of `cuBQL/CuBQLBackend.h`
- Moved the call to `mesh->getDD()` outside of the OMP region since I was running into an illegal address error (possibly because the pointer for the mesh object isn't available on device?) 
- Prepocessor guard `#if DP_OMP` inside of `cuBQL/Triangles.cu` switched to use the new CMAKE variable `DPRT_OMP`
- Ensure the prefix `dprt_` is used consistently with `dbg_rayID` inside of `cuBQL/InstanceGroup.cu`

As a side note, I am especially interested in the work with the OpenMP pathway as an FP64 capable OpenMP ray tracer is would be extremely helpful for the work I am doing with @pshriwise as part of the [XDG project](https://github.com/xdg-org/xdg) where I have made a start playing around with DPRT as a GPU ray tracing backend to our CAD meshes. 

Closes #16 